### PR TITLE
Review's price field made nonmandatory

### DIFF
--- a/src/Admin/presenters/ReviewsPresenter.php
+++ b/src/Admin/presenters/ReviewsPresenter.php
@@ -141,7 +141,7 @@ class ReviewsPresenter extends BasePresenter
         $form->addText('name', 'Name')->setRequired();
         $form->addSelect('product', 'Product')->setItems($productsForSelect)->setRequired();
         $form->addText('date', 'Date')->setAttribute('class', array('datepicker'))->setRequired('Fill in date of this review.');
-        $form->addText('price', 'Price')->setRequired();
+        $form->addText('price', 'Price');
         $form->addTextArea('text', 'Text')->setAttribute('class', 'form-control editor');
 
         $form->addCheckbox('visitable', 'Visitable');


### PR DESCRIPTION
The review's price field doesn't need to be mandatory for creating or updating the review. We can check for it later in the template - if the price is empty, we will hide the "Price:" label.
