### PR TITLE
Added error handling if product doesn't exist

### DIFF
--- a/src/Frontend/presenters/ProductsPresenter.php
+++ b/src/Frontend/presenters/ProductsPresenter.php
@@ -65,6 +65,9 @@ class ProductsPresenter extends BasePresenter
                 'slug' => $slug
             ));
 
+            if (!is_object($this->product))
+                throw new \Nette\Application\BadRequestException();            
+
             $accessories = $this->product->getAccessories();
 
             foreach (explode(",", $accessories) as $accessory) {


### PR DESCRIPTION
If the address is misspelled throw 404 error instead of 500...
This will work better... :)
